### PR TITLE
Fix docker-compose restart error.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        busybox:latest
 
 ADD         etcd-v0.4.6-linux-amd64/etcd        /bin/etcd
 


### PR DESCRIPTION
With scratch base image you can't restart etcd when using docker-compose:

```
Cannot start container 0137d4e518d40f428ee7fc09de75f3c255a4433268d31e9ba031c72e0e007436: exec: "/bin/echo": stat /bin/echo: no such file or directory
```

Using busybox this error is fixed.
Image size difference is not relevant.

```
REPOSITORY           TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
tpires/etcd          latest              ee732828fd96        9 minutes ago       19.81 MB
microbox/etcd        latest              f0818f77b523        5 months ago        17.38 MB
```

Signed-off-by: Tiago Pires tandrepires@gmail.com
